### PR TITLE
Consolidate the OHContactsDataSource API

### DIFF
--- a/Example/Ohana/OHBasicContactPickerTableViewController.m
+++ b/Example/Ohana/OHBasicContactPickerTableViewController.m
@@ -57,7 +57,7 @@
         _dataSource = [[OHContactsDataSource alloc] initWithDataProviders:[NSOrderedSet orderedSetWithObjects:dataProvider, nil]
                                                            postProcessors:[NSOrderedSet orderedSetWithObjects:alphabeticalSortProcessor, nil]];
 
-        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull contacts) {
             self.contactsByLetter = [self _contactsByLetterDictionaryForContacts:self.dataSource.contacts];
             [self.tableView reloadData];
         }];

--- a/Example/Ohana/OHContactSelectionTableViewController.m
+++ b/Example/Ohana/OHContactSelectionTableViewController.m
@@ -57,7 +57,7 @@
         _dataSource = [[OHContactsDataSource alloc] initWithDataProviders:[NSOrderedSet orderedSetWithObjects:dataProvider, nil]
                                                            postProcessors:[NSOrderedSet orderedSetWithObjects:alphabeticalSortProcessor, nil]];
 
-        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull contacts) {
             self.contactsByLetter = [self _contactsByLetterDictionaryForContacts:self.dataSource.contacts];
             [self.tableView reloadData];
         }];

--- a/Example/Ohana/OHFuzzySearchTableViewController.m
+++ b/Example/Ohana/OHFuzzySearchTableViewController.m
@@ -61,7 +61,7 @@
         _dataSource = [[OHContactsDataSource alloc] initWithDataProviders:[NSOrderedSet orderedSetWithObjects:dataProvider, nil]
                                                            postProcessors:[NSOrderedSet orderedSetWithObjects:alphabeticalSortProcessor, splitOnPhoneProcessor, nil]];
 
-        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull contacts) {
             self.fuzzyMatchingUtility = [[OHFuzzyMatchingUtility alloc] initWithContacts:self.dataSource.contacts];
             dispatch_async(dispatch_get_main_queue(), ^(){
                 [self.tableView reloadData];

--- a/Example/Ohana/OHPhoneNumberPickerTableViewController.m
+++ b/Example/Ohana/OHPhoneNumberPickerTableViewController.m
@@ -52,7 +52,7 @@
         _dataSource = [[OHContactsDataSource alloc] initWithDataProviders:[NSOrderedSet orderedSetWithObjects:dataProvider, nil]
                                                            postProcessors:[NSOrderedSet orderedSetWithObjects:alphabeticalSortProcessor, splitOnPhoneProcessor, nil]];
 
-        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+        [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull contacts) {
             [self.tableView reloadData];
         }];
 

--- a/Example/Tests/OHContactsDataSourceTests.m
+++ b/Example/Tests/OHContactsDataSourceTests.m
@@ -29,6 +29,13 @@
 
 #import "NSOrderedSetMake+Internal.h"
 
+@interface OHContactsDataSource (Testing)
+
+@property (nonatomic, readwrite) NSOrderedSet<id<OHContactsDataProviderProtocol>> *dataProviders;
+@property (nonatomic, readwrite, nullable) NSOrderedSet<id<OHContactsPostProcessorProtocol>> *postProcessors;
+
+@end
+
 @interface OHContactsDataSourceTests : XCTestCase
 
 @property (nonatomic) id dataProviderMock;
@@ -62,8 +69,6 @@
 
     XCTAssertNil(dataSource.selectionFilters);
 
-    XCTAssertNotNil(dataSource.onContactsDataSourceLoadedProvidersSignal);
-    XCTAssertNotNil(dataSource.onContactsDataSourcePostProcessorsFinishedSignal);
     XCTAssertNotNil(dataSource.onContactsDataSourceReadySignal);
     XCTAssertNotNil(dataSource.onContactsDataSourceSelectedContactsSignal);
     XCTAssertNotNil(dataSource.onContactsDataSourceDeselectedContactsSignal);
@@ -248,17 +253,9 @@
     NSOrderedSet *contacts = NSOrderedSetMake([[OHContact alloc] init], [[OHContact alloc] init]);
     OCMStub([self.dataProviderMock contacts]).andReturn(contacts);
 
-    XCTestExpectation *onLoadedProvidersExpectation = [self expectationWithDescription:@"Data source loaded providers signal should have fired"];
-    [dataSource.onContactsDataSourceLoadedProvidersSignal addObserver:self callback:^(typeof(self) self) {
-        [onLoadedProvidersExpectation fulfill];
-    }];
-
-    [dataSource.onContactsDataSourcePostProcessorsFinishedSignal addObserver:self callback:^(typeof(self) self) {
-        XCTAssert(NO);
-    }];
-
     XCTestExpectation *onReadyExpectation = [self expectationWithDescription:@"Data source ready signal should have fired"];
-    [dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+
+    [dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(id  _Nonnull self, NSOrderedSet<OHContact *> * _Nullable contacts) {
         XCTAssert([dataSource.contacts isEqualToOrderedSet:contacts]);
         [onReadyExpectation fulfill];
     }];
@@ -284,18 +281,8 @@
     OHContactsDataSource *dataSource = [[OHContactsDataSource alloc] initWithDataProviders:NSOrderedSetMake(self.dataProviderMock)
                                                                             postProcessors:NSOrderedSetMake(postProcessorMock)];
 
-    XCTestExpectation *onLoadedProvidersExpectation = [self expectationWithDescription:@"Data source loaded providers signal should have fired"];
-    [dataSource.onContactsDataSourceLoadedProvidersSignal addObserver:self callback:^(typeof(self) self) {
-        [onLoadedProvidersExpectation fulfill];
-    }];
-
-    XCTestExpectation *onPostProcessorsFinishedSignal = [self expectationWithDescription:@"Post processors finished signal should have fired"];
-    [dataSource.onContactsDataSourcePostProcessorsFinishedSignal addObserver:self callback:^(typeof(self) self) {
-        [onPostProcessorsFinishedSignal fulfill];
-    }];
-
     XCTestExpectation *onReadyExpectation = [self expectationWithDescription:@"Data source ready signal should have fired"];
-    [dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self) {
+    [dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(id  _Nonnull self, NSOrderedSet<OHContact *> * _Nullable contacts) {
         XCTAssert([dataSource.contacts isEqualToOrderedSet:contacts]);
         [onReadyExpectation fulfill];
     }];

--- a/Ohana/Classes/Core/OHContactsDataSource.h
+++ b/Ohana/Classes/Core/OHContactsDataSource.h
@@ -33,6 +33,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
+ * Signal fired after the contacts are ready to be read.
+ * The contacts property of the DataSource is now ready. The contacts are also provided in the signal.
+ */
+
+CreateSignalInterface(OHContactsDataSourceReadySignal, NSOrderedSet<OHContact *> *contacts);
+
+/**
  *  Signal fired after the data source selects contacts
  *
  *  @discussion selectedContacts contains contacts that have passed through the selection filters and were not already selected
@@ -44,19 +51,9 @@ CreateSignalInterface(OHContactsDataSourceSelectedContactsSignal, NSOrderedSet<O
  *
  *  @discussion deselectedContacts contains contacts that have passed through the selection filters and were previously selected
  */
-CreateSignalInterface(OHContactsDataSourceDeselectedContactsSignal, NSOrderedSet<OHContact *> *deselectedContacts);
+CreateSignalInterface(OHContactsDataSourceDeselectedContactsSignal, NSOrderedSet<OHContact *> *_Nullable deselectedContacts);
 
 @interface OHContactsDataSource : NSObject
-
-/**
- *  Ordered set of data providers that the data source was initialized with
- */
-@property (nonatomic, readonly) NSOrderedSet<id<OHContactsDataProviderProtocol>> *dataProviders;
-
-/**
- *  Ordered set of post processors that the data source was initialized with
- */
-@property (nonatomic, readonly, nullable) NSOrderedSet<id<OHContactsPostProcessorProtocol>> *postProcessors;
 
 /**
  *  Ordered set of selection filters
@@ -66,21 +63,11 @@ CreateSignalInterface(OHContactsDataSourceDeselectedContactsSignal, NSOrderedSet
 @property (nonatomic, nullable) NSOrderedSet<id<OHContactsSelectionFilterProtocol>> *selectionFilters;
 
 /**
- *  Signal fired after the data source has finished loading all of its data providers
- */
-@property (nonatomic, readonly) UBEmptySignal *onContactsDataSourceLoadedProvidersSignal;
-
-/**
- *  Signal fired after the data source has finished running all of its post processors
- */
-@property (nonatomic, readonly) UBEmptySignal *onContactsDataSourcePostProcessorsFinishedSignal;
-
-/**
  *  Signal fired after the data source is ready to be used
  *
  *  @discussion When this signal is fired, the `contacts` property will have been set
  */
-@property (nonatomic, readonly) UBEmptySignal *onContactsDataSourceReadySignal;
+@property (nonatomic, readonly) OHContactsDataSourceReadySignal *onContactsDataSourceReadySignal;
 
 /**
  *  Signal fired after the data source selects contacts


### PR DESCRIPTION
Removed signals which exposed internal functionality on the public API:
* onContactsDataSourceLoadedProvidersSignal
* onContactsDataSourcePostProcessorsFinishedSignal

Firing available contacts in the onContactsDataSourceReadySignal

Removed implementation detail fields from the public API:
* postProcessors
* dataProviders

closes: https://github.com/uber/ohana-ios/issues/31