### PR TITLE
Improved auth API for default DataProviders

### DIFF
--- a/Example/Ohana/OHBasicContactPhotosPicker.swift
+++ b/Example/Ohana/OHBasicContactPhotosPicker.swift
@@ -60,23 +60,14 @@ class OHBasicContactPhotosPicker : UITableViewController, OHCNContactsDataProvid
     // MARK: OHCNContactsDataProviderDelegate
 
     @available(iOS 9.0, *)
-    func dataProviderDidHitContactsAuthenticationChallenge(_ dataProvider: OHCNContactsDataProvider) {
-        let store = CNContactStore()
-        store.requestAccess(for: .contacts) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitCNContactsAuthChallenge(_ dataProvider: OHCNContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: OHABAddressBookContactsDataProviderDelegate
 
-    func dataProviderDidHitAddressBookAuthenticationChallenge(_ dataProvider: OHABAddressBookContactsDataProvider) {
-        ABAddressBookRequestAccessWithCompletion(nil) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitABAddressBookAuthChallenge(_ dataProvider: OHABAddressBookContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: UITableViewDataSource

--- a/Example/Ohana/OHBasicContactPickerTableViewController.m
+++ b/Example/Ohana/OHBasicContactPickerTableViewController.m
@@ -141,25 +141,16 @@
 
 #pragma mark - OHCNContactsDataProviderDelegate
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    CNContactStore *contactStore = [[CNContactStore alloc] init];
-    [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError *_Nullable error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    }];
+    userAuthenticationTrigger();
 }
 
 #pragma mark - OHABAddressBookContactsDataProviderDelegate
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    ABAddressBookRequestAccessWithCompletion(nil, ^(bool granted, CFErrorRef error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    });
+    userAuthenticationTrigger();
 }
 
 #pragma mark - Private

--- a/Example/Ohana/OHContactSelectionTableViewController.m
+++ b/Example/Ohana/OHContactSelectionTableViewController.m
@@ -158,25 +158,16 @@
 
 #pragma mark - OHCNContactsDataProviderDelegate
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    CNContactStore *contactStore = [[CNContactStore alloc] init];
-    [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError *_Nullable error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    }];
+    userAuthenticationTrigger();
 }
 
 #pragma mark - OHABAddressBookContactsDataProviderDelegate
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHABAddressBookContactsDataProvider *)dataProvider
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    ABAddressBookRequestAccessWithCompletion(nil, ^(bool granted, CFErrorRef error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    });
+    userAuthenticationTrigger();
 }
 
 #pragma mark - Actions

--- a/Example/Ohana/OHFuzzySearchTableViewController.m
+++ b/Example/Ohana/OHFuzzySearchTableViewController.m
@@ -153,25 +153,16 @@
 
 #pragma mark - OHCNContactsDataProviderDelegate
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    CNContactStore *contactStore = [[CNContactStore alloc] init];
-    [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError *_Nullable error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    }];
+    userAuthenticationTrigger();
 }
 
 #pragma mark - OHABAddressBookContactsDataProviderDelegate
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHABAddressBookContactsDataProvider *)dataProvider
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    ABAddressBookRequestAccessWithCompletion(nil, ^(bool granted, CFErrorRef error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    });
+    userAuthenticationTrigger();
 }
 
 #pragma mark - UISearchResultsUpdating

--- a/Example/Ohana/OHMaximumSelectedCountPicker.swift
+++ b/Example/Ohana/OHMaximumSelectedCountPicker.swift
@@ -77,23 +77,14 @@ class OHMaximumSelectedCountPicker: UITableViewController, OHCNContactsDataProvi
     // MARK: OHCNContactsDataProviderDelegate
 
     @available(iOS 9.0, *)
-    func dataProviderDidHitContactsAuthenticationChallenge(_ dataProvider: OHCNContactsDataProvider) {
-        let store = CNContactStore()
-        store.requestAccess(for: .contacts) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitCNContactsAuthChallenge(_ dataProvider: OHCNContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: OHABAddressBookContactsDataProviderDelegate
 
-    func dataProviderDidHitAddressBookAuthenticationChallenge(_ dataProvider: OHABAddressBookContactsDataProvider) {
-        ABAddressBookRequestAccessWithCompletion(nil) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitABAddressBookAuthChallenge(_ dataProvider: OHABAddressBookContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: UITableViewDataSource

--- a/Example/Ohana/OHPhoneNumberPickerTableViewController.m
+++ b/Example/Ohana/OHPhoneNumberPickerTableViewController.m
@@ -118,25 +118,16 @@
 
 #pragma mark - OHCNContactsDataProviderDelegate
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    CNContactStore *contactStore = [[CNContactStore alloc] init];
-    [contactStore requestAccessForEntityType:CNEntityTypeContacts completionHandler:^(BOOL granted, NSError *_Nullable error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    }];
+    userAuthenticationTrigger();
 }
 
 #pragma mark - OHABAddressBookContactsDataProviderDelegate
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHABAddressBookContactsDataProvider *)dataProvider
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
-    ABAddressBookRequestAccessWithCompletion(nil, ^(bool granted, CFErrorRef error) {
-        if (granted) {
-            [dataProvider loadContacts];
-        }
-    });
+    userAuthenticationTrigger();
 }
 
 #pragma mark - Private

--- a/Example/Ohana/OHPhoneOrEmailPicker.swift
+++ b/Example/Ohana/OHPhoneOrEmailPicker.swift
@@ -79,23 +79,14 @@ class OHPhoneOrEmailPicker: UITableViewController, OHCNContactsDataProviderDeleg
     // MARK: OHCNContactsDataProviderDelegate
 
     @available(iOS 9.0, *)
-    func dataProviderDidHitContactsAuthenticationChallenge(_ dataProvider: OHCNContactsDataProvider) {
-        let store = CNContactStore()
-        store.requestAccess(for: .contacts) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitCNContactsAuthChallenge(_ dataProvider: OHCNContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: OHABAddressBookContactsDataProviderDelegate
 
-    func dataProviderDidHitAddressBookAuthenticationChallenge(_ dataProvider: OHABAddressBookContactsDataProvider) {
-        ABAddressBookRequestAccessWithCompletion(nil) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitABAddressBookAuthChallenge(_ dataProvider: OHABAddressBookContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: UITableViewDataSource

--- a/Example/Ohana/OHSMSPicker.swift
+++ b/Example/Ohana/OHSMSPicker.swift
@@ -86,23 +86,14 @@ class OHSMSPicker: UITableViewController, OHCNContactsDataProviderDelegate, OHAB
     // MARK: OHCNContactsDataProviderDelegate
 
     @available(iOS 9.0, *)
-    func dataProviderDidHitContactsAuthenticationChallenge(_ dataProvider: OHCNContactsDataProvider) {
-        let store = CNContactStore()
-        store.requestAccess(for: .contacts) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitCNContactsAuthChallenge(_ dataProvider: OHCNContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: OHABAddressBookContactsDataProviderDelegate
 
-    func dataProviderDidHitAddressBookAuthenticationChallenge(_ dataProvider: OHABAddressBookContactsDataProvider) {
-        ABAddressBookRequestAccessWithCompletion(nil) { (granted, error) in
-            if granted {
-                dataProvider.loadContacts()
-            }
-        }
+    func dataProviderHitABAddressBookAuthChallenge(_ dataProvider: OHABAddressBookContactsDataProvider, requiresUserAuthentication userAuthenticationTrigger: @escaping () -> Void) {
+        userAuthenticationTrigger()
     }
 
     // MARK: MFMessageComposeViewControllerDelegate

--- a/Example/Tests/OHABAddressBookContactsDataProviderTests.m
+++ b/Example/Tests/OHABAddressBookContactsDataProviderTests.m
@@ -123,7 +123,7 @@ typedef void (^OHABContactsFetchFailedBlock)(NSError *error);
 
 #pragma mark - OHABAddressBookContactsDataProviderDelegate
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHABAddressBookContactsDataProvider *)dataProvider
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
     [self.authenticationRequestExpectation fulfill];
 }

--- a/Example/Tests/OHCNContactsDataProviderTests.m
+++ b/Example/Tests/OHCNContactsDataProviderTests.m
@@ -121,7 +121,7 @@ typedef void (^OHCNContactsFetchFailedBlock)(NSError *error);
 
 #pragma mark - UBCLCNContactsDataProvider
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger
 {
     [self.authenticationRequestExpectation fulfill];
 }

--- a/Ohana/Classes/Common/DataProviders/OHABAddressBookContactsDataProvider.h
+++ b/Ohana/Classes/Common/DataProviders/OHABAddressBookContactsDataProvider.h
@@ -33,7 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol OHABAddressBookContactsDataProviderDelegate <NSObject>
 
-- (void)dataProviderDidHitAddressBookAuthenticationChallenge:(OHABAddressBookContactsDataProvider *)dataProvider;
+/**
+ * dataProvider:requiresUserAuthentication: is called if the OHABAddressBookContactsDataProvider is unable to 
+ * access the system contacts because access has not yet been granted.
+ * The consumer may chose to trigger the user authentication prompt by invoking the userAuthenticationTrigger
+ * callback. Once the user has authenticated, contact loading will be attempted again.
+ */
+- (void)dataProviderHitABAddressBookAuthChallenge:(OHABAddressBookContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger;
 
 @end
 

--- a/Ohana/Classes/Common/DataProviders/OHCNContactsDataProvider.h
+++ b/Ohana/Classes/Common/DataProviders/OHCNContactsDataProvider.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_CLASS_AVAILABLE_IOS(9_0)
 @protocol OHCNContactsDataProviderDelegate <NSObject>
 
-- (void)dataProviderDidHitContactsAuthenticationChallenge:(OHCNContactsDataProvider *)dataProvider;
+- (void)dataProviderHitCNContactsAuthChallenge:(OHCNContactsDataProvider *)dataProvider requiresUserAuthentication:(void (^)())userAuthenticationTrigger;
 
 @end
 


### PR DESCRIPTION
OHCNContactsDataProvider and OHABAddressBookContactsDataProvider
now encapsulate their own auth challenge code instead of expecting
the consumer to implement it.
The each provide a callback to be exercised when the auth challenge
is required.

closes: https://github.com/uber/ohana-ios/issues/28