### PR TITLE
Following Changes:

### DIFF
--- a/Example/Ohana/OHBasicContactPickerTableViewController.m
+++ b/Example/Ohana/OHBasicContactPickerTableViewController.m
@@ -59,7 +59,9 @@
 
         [self.dataSource.onContactsDataSourceReadySignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull contacts) {
             self.contactsByLetter = [self _contactsByLetterDictionaryForContacts:self.dataSource.contacts];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self.tableView reloadData];
+            });
         }];
 
         [self.dataSource.onContactsDataSourceSelectedContactsSignal addObserver:self callback:^(typeof(self) self, NSOrderedSet<OHContact *> * _Nonnull selectedContacts) {

--- a/Example/Ohana/OHSMSPicker.swift
+++ b/Example/Ohana/OHSMSPicker.swift
@@ -62,7 +62,7 @@ class OHSMSPicker: UITableViewController, OHCNContactsDataProviderDelegate, OHAB
                     if let phoneNumber = contact.contactFields?.object(at: 0) as? OHContactField {
                         composer.recipients = [ phoneNumber.value ]
                     }
-                    composer.messageComposeDelegate = self as? MFMessageComposeViewControllerDelegate
+                    composer.messageComposeDelegate = self
                     self?.present(composer, animated: true, completion: nil)
                 } else {
                     let alertController = UIAlertController(title: "Unable to Send SMS", message: "Please run on a device that can send SMS messages.", preferredStyle: .alert)

--- a/Ohana/Classes/Common/DataProviders/OHABAddressBookContactsDataProvider.h
+++ b/Ohana/Classes/Common/DataProviders/OHABAddressBookContactsDataProvider.h
@@ -49,6 +49,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 
++ (OHABAddressBookContactsDataProvider *)new NS_UNAVAILABLE;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Ohana/Classes/Common/DataProviders/OHCNContactsDataProvider.h
+++ b/Ohana/Classes/Common/DataProviders/OHCNContactsDataProvider.h
@@ -41,7 +41,7 @@ NS_CLASS_AVAILABLE_IOS(9_0)
 NS_CLASS_AVAILABLE_IOS(9_0)
 @interface OHCNContactsDataProvider : NSObject <OHContactsDataProviderProtocol>
 
-extern NSString *_Nonnull kOHCNContactsDataProviderContactIdentifierKey;  // Identifier unique among contacts on the device (NSString *)
+extern NSString *kOHCNContactsDataProviderContactIdentifierKey;  // Identifier unique among contacts on the device (NSString *)
 
 /**
  *  By default, the data provider does not load a thumbnail image to conserve space. Set this to `YES` to load thumbnail image.
@@ -51,6 +51,8 @@ extern NSString *_Nonnull kOHCNContactsDataProviderContactIdentifierKey;  // Ide
 - (instancetype)initWithDelegate:(id<OHCNContactsDataProviderDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
+
++ (OHCNContactsDataProvider *)new NS_UNAVAILABLE;
 
 @end
 

--- a/Ohana/Classes/Common/PostProcessors/OHPhoneNumberFormattingPostProcessor.h
+++ b/Ohana/Classes/Common/PostProcessors/OHPhoneNumberFormattingPostProcessor.h
@@ -38,10 +38,10 @@ typedef NS_OPTIONS (NSInteger, OHPhoneNumberFormat) {
 
 @interface OHPhoneNumberFormattingPostProcessor : NSObject <OHContactsPostProcessorProtocol>
 
-extern NSString *_Nonnull kOHFormattedPhoneNumberE164;          // Phone number in E164 format (NSString *)
-extern NSString *_Nonnull kOHFormattedPhoneNumberInternational; // Phone number in International format (NSString *)
-extern NSString *_Nonnull kOHFormattedPhoneNumberNational;      // Phone number in National format (NSString *)
-extern NSString *_Nonnull kOHFormattedPhoneNumberRFC3966;       // Phone number in RFC3966 format (NSString *)
+extern NSString *kOHFormattedPhoneNumberE164;          // Phone number in E164 format (NSString *)
+extern NSString *kOHFormattedPhoneNumberInternational; // Phone number in International format (NSString *)
+extern NSString *kOHFormattedPhoneNumberNational;      // Phone number in National format (NSString *)
+extern NSString *kOHFormattedPhoneNumberRFC3966;       // Phone number in RFC3966 format (NSString *)
 
 /**
  *  Bit mask of formats to use

--- a/Ohana/Classes/Common/PostProcessors/OHStatisticsPostProcessor.h
+++ b/Ohana/Classes/Common/PostProcessors/OHStatisticsPostProcessor.h
@@ -31,10 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface OHStatisticsPostProcessor : NSObject <OHContactsPostProcessorProtocol>
 
-extern NSString *_Nonnull kOHStatisticsNumberOfContactFields;  // Total number of contact fields (NSNumber)
-extern NSString *_Nonnull kOHStatisticsNumberOfPhoneNumbers;   // Number of contact fields of type UBContactFieldTypePhoneNumber (NSNumber *)
-extern NSString *_Nonnull kOHStatisticsNumberOfEmailAddresses; // Number of contact fields of type UBContactFieldTypeEmailAddress (NSNumber *)
-extern NSString *_Nonnull kOHStatisticsHasMobilePhoneNumber;   // Whether or not contact has a phone number with label of type "mobile" or "iPhone" (NSNumber *)
+extern NSString *kOHStatisticsNumberOfContactFields;  // Total number of contact fields (NSNumber)
+extern NSString *kOHStatisticsNumberOfPhoneNumbers;   // Number of contact fields of type UBContactFieldTypePhoneNumber (NSNumber *)
+extern NSString *kOHStatisticsNumberOfEmailAddresses; // Number of contact fields of type UBContactFieldTypeEmailAddress (NSNumber *)
+extern NSString *kOHStatisticsHasMobilePhoneNumber;   // Whether or not contact has a phone number with label of type "mobile" or "iPhone" (NSNumber *)
 
 @end
 

--- a/Ohana/Classes/Core/OHContactsDataSource.m
+++ b/Ohana/Classes/Core/OHContactsDataSource.m
@@ -67,7 +67,7 @@ CreateSignalImplementation(OHContactsDataSourceDeselectedContactsSignal, NSSet<O
         _onContactsDataSourceDeselectedContactsSignal = [[OHContactsDataSourceDeselectedContactsSignal alloc] init];
 
         _allContacts = [[NSMutableOrderedSet<OHContact *> alloc] init];
-        _selectedContacts = [[NSMutableOrderedSet alloc] init];
+        _selectedContacts = [[NSMutableOrderedSet<OHContact *> alloc] init];
 
 
         _completedDataProviders = [[NSMutableSet<id<OHContactsDataProviderProtocol>> alloc] initWithCapacity:dataProviders.count];


### PR DESCRIPTION
1. Fix issue with Example app not reloading the table view first time with Contacts access permission is not given to the app.
2. Added `+new` function as NS_UNAVAILABLE in OHABAddressBookContactsDataProvider and OHCNContactsDataProvider
3. Removed compiler warning in OHSMSPicker
4. Removed unwanted _Nonnull in extern declarations as the header function already declares NS_ASSUME_NONNULL_BEGIN/NS_ASSUME_NONNULL_END